### PR TITLE
Treat all requests as .json requests.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,19 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
+  before_action :set_format
+
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation) }
       devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:username, :email, :password, :password_confirmation) }
+  end
+
+  private
+
+  def set_format
+    request.format = :json
   end
 
 end


### PR DESCRIPTION
Requests will not need to have the .json extension.
